### PR TITLE
Use latest version if not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Run Nigiri Bitcoin in your Github Action
 
 ## `version`
 
-**Optional** The Nigiri version tag. Default `"v0.2.0"`.
+**Optional** The Nigiri version tag. Default to latest.
 
 ## `repository_url`
 

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,6 @@ inputs:
   version:
     description: "nigiri version to install"
     required: false
-    default: "v0.2.0"
   repository_url:
     description: "Github repository URL of the repository with release artifacts"
     required: false

--- a/index.js
+++ b/index.js
@@ -17,7 +17,9 @@ async function run() {
     core.info(`Repository URL        ${repository}`);
 
     const name = "nigiri";
-    const downloadURL = `${repository}/releases/download/${version}/nigiri-linux-amd64`;
+    const downloadURL = version ?
+      `${repository}/releases/download/${version}/nigiri-linux-amd64` :
+      `${repository}/releases/latest/download/nigiri-linux-amd64`;
 
     let cachedPath = tc.find(name, version)
     if (!cachedPath) {


### PR DESCRIPTION
Use latest Nigiri version if not specified. 
Doesn't uses optional `default` value in action.yml.

Please review @tiero 