### PR TITLE
Add 'use_ln' to sample in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ Run Nigiri Bitcoin in your Github Action
   uses: vulpemventures/nigiri-github-action@v1
 ```
 
-### start Bitcoin-only services
+### start Bitcoin-only services with LN
 
 ```yml
   name: Run Nigiri
   uses: vulpemventures/nigiri-github-action@v1
   with:
     use_liquid: false
+    use_ln: true
 ```
 


### PR DESCRIPTION
I set the value to `true`, because the default is `false`, so stating in the example that you have to write `use_ln: false` if you don't want to start the LN containers is kind of wrong.